### PR TITLE
Adds a `CopyableCrystallisData` mixin + fix test/example formatting

### DIFF
--- a/packages/crystallis/lib/runtime/mixin.dart
+++ b/packages/crystallis/lib/runtime/mixin.dart
@@ -142,21 +142,15 @@ abstract mixin class MutableCrystallisData implements CrystallisData {
         final thisMeta = metadata[name]!;
         final otherMeta = other.metadata[name];
 
-        /// TODO(kerberjg): dart-format-off is not working here...
-        // skip when...
-        if ( //
-        otherMeta ==
-                null // missing
-                ||
-            otherMeta.type !=
-                thisMeta
-                    .type // type-mismatched fields
-                    ||
-            !thisMeta
-                .mutable // this field is immutable
-                ) {
+        // dart format off
+        if (
+          otherMeta == null // missing
+          || otherMeta.type != thisMeta .type // type-mismatched fields
+          || !thisMeta.mutable // this field is immutable
+        ) {
           continue;
         }
+        // dart format on
       }
 
       final value = other.get(name);

--- a/packages/crystallis/lib/runtime/mixin.dart
+++ b/packages/crystallis/lib/runtime/mixin.dart
@@ -190,3 +190,18 @@ abstract mixin class ImmutableCrystallisData implements CrystallisData {
     );
   }
 }
+
+/// Mixin class for data classes that support copy methods (e.g. [copyWith]).
+/// Applied to classes generated with [Crystallise] when [enableCopyWith] is true
+abstract mixin class CopyableCrystallisData<T extends CrystallisData> implements CrystallisData {
+  /// Creates a copy of this object, with the same values for all fields.
+  /// If [Crystallise.useDeepCopy] is true, performs a deep copy of all fields that are collections or other [CrystallisData] objects.
+  /// Otherwise, performs a shallow copy (i.e. just copies references) for all fields.
+  T Function() get copyWith;
+
+  /// Creates a copy of this object, with the same values for all fields except those provided in [other].
+  /// Fields from [other] that are missing, null, or of the wrong type are ignored and retain their original value in the copy.
+  /// If [Crystallise.useDeepCopy] is true, performs a deep copy of all fields that are collections or other [CrystallisData] objects.
+  /// Otherwise, performs a shallow copy (i.e. just copies references) for all fields.
+  T copyFrom(CrystallisData other);
+}

--- a/packages/crystallis_generator/lib/crystallis_generator.dart
+++ b/packages/crystallis_generator/lib/crystallis_generator.dart
@@ -6,13 +6,29 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:crystallis/crystallis.dart';
 import 'package:crystallis/runtime/serializer.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:source_gen/source_gen.dart';
 
 Builder crystallisBuilder(BuilderOptions options) {
   return LibraryBuilder(
-    CrystallisGenerator(), //
-    generatedExtension: '.data.g.dart', //
-    options: options, //
+    CrystallisGenerator(),
+    generatedExtension: '.data.g.dart',
+    options: options,
+    formatOutput: (code, langVersion) {
+      // check if running in a test
+      final isTest = code.contains("package:cg_test/");
+
+      const String defaultFileHeader = '// GENERATED CODE - DO NOT MODIFY BY HAND';
+      const String defaultDartFormatWidth = '// dart format width=80';
+      const String testDartFormatWidth = '// dart format width=1000';
+
+      code =
+          '$defaultFileHeader\n'
+          '${isTest ? testDartFormatWidth : defaultDartFormatWidth}\n'
+          '${code.startsWith('$defaultFileHeader\n') ? code.substring(defaultFileHeader.length) : code}';
+
+      return DartFormatter(languageVersion: langVersion).format(code);
+    },
   );
 }
 
@@ -347,7 +363,7 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
           if (f.type.isNullable) {
             buffer.write('this.${f.name} == null ? null : ');
           }
-          buffer.writeln('$open...${f.type.isNullable ? '?' : ''}this.${f.name} $close)');
+          buffer.writeln('$open...${f.type.isNullable ? '?' : ''}this.${f.name}$close)');
           buffer.write('$prefix  : (');
           if (f.type.isNullable) buffer.write('${f.name} == null ? null : ');
           buffer.writeln('$open...${f.name} as ${_nonNullableType(f.type)}$close),');

--- a/packages/crystallis_generator/lib/crystallis_generator.dart
+++ b/packages/crystallis_generator/lib/crystallis_generator.dart
@@ -116,6 +116,7 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
     buffer.writeln(
       'class $publicName extends $className with CrystallisData' +
           ', ${mutable ? "MutableCrystallisData" : "ImmutableCrystallisData"}' +
+          ', ${enableCopyWith ? "CopyableCrystallisData<$publicName>" : ""} ' +
           ' {',
     );
 
@@ -317,6 +318,7 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
 
     // copyWith
     if (enableCopyWith) {
+      buffer.writeln('  @override');
       buffer.write('  $publicName Function({');
       for (final f in fields) {
         buffer.write('${f.type.getDisplayString()} ${f.name},');
@@ -357,6 +359,7 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
       buffer.writeln();
 
       // copyFrom (like setFrom, but returns a new instance instead of modifying this)
+      buffer.writeln('  @override');
       buffer.write('  $publicName copyFrom(CrystallisData other) {');
       buffer.write('    return _innerCopyWith(');
       for (final f in fields) {

--- a/packages/crystallis_generator/lib/crystallis_generator.dart
+++ b/packages/crystallis_generator/lib/crystallis_generator.dart
@@ -18,13 +18,23 @@ Builder crystallisBuilder(BuilderOptions options) {
       // check if running in a test
       final isTest = code.contains("package:cg_test/");
 
+      // check if running in an example
+      // (package name ends with '_example')
+      final isExample = code
+          .split('\n') //
+          .where((line) => line.startsWith("import 'package:"))
+          .map((line) => line.split('package:')[1].split('/')[0])
+          .any((packageName) => packageName.endsWith('_example'));
+
       const String defaultFileHeader = '// GENERATED CODE - DO NOT MODIFY BY HAND';
       const String defaultDartFormatWidth = '// dart format width=80';
       const String testDartFormatWidth = '// dart format width=1000';
+      const String disableAnalyzer = '// ignore_for_file: type=lint\n';
 
       code =
           '$defaultFileHeader\n'
           '${isTest ? testDartFormatWidth : defaultDartFormatWidth}\n'
+          '${isTest || isExample ? '' : disableAnalyzer}\n'
           '${code.startsWith('$defaultFileHeader\n') ? code.substring(defaultFileHeader.length) : code}';
 
       return DartFormatter(languageVersion: langVersion).format(code);

--- a/packages/crystallis_generator/pubspec.yaml
+++ b/packages/crystallis_generator/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   build: ^4.0.4
   meta: ^1.9.0
   source_gen: ^4.2.0
+  dart_style: ^3.1.7
   crystallis: ">=0.0.4 <0.1.0"
 
 dev_dependencies:

--- a/packages/crystallis_generator/test/generated_golden_test.dart
+++ b/packages/crystallis_generator/test/generated_golden_test.dart
@@ -3,7 +3,7 @@ import 'package:build_test/build_test.dart';
 import 'package:crystallis_generator/crystallis_generator.dart';
 import 'package:test/test.dart';
 
-const String outputPackage = 'a';
+const String outputPackage = 'cg_test';
 
 enum TestEntry {
   mutable(


### PR DESCRIPTION
Summary of changes:

- Adds a mixin to be applied to generated `CrystallisData` subclasses that have `CrystallisData.enableCopyWith` to provide a supertype interface that you can use to group/call `copyWith`/`copyFrom` methods.
- Allows setting split formatting settings for tests/examples for consistency
- Fixes #10
> _"Composition over Inheritance? Why choose! xD"_ ~ Jamie Kerber, 2026

Notes to reviewer:
- Dart does not (and will not - https://github.com/dart-lang/language/issues/1383 ) allow overriding method parameters, making it difficult to specify the return type on the Function returned by `copyWith`. An ideal solution would be something like `TypedCallback<T>` but AFAIK that doesn't exist. Ideas are welcome 😢