### PR TITLE
Added conditional import for serializer lib

### DIFF
--- a/packages/crystallis_generator/lib/crystallis_generator.dart
+++ b/packages/crystallis_generator/lib/crystallis_generator.dart
@@ -105,14 +105,14 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
     final String className = element.name ?? "";
     final String publicName = className + crystallisSuffix;
     final bool mutable = annotation.peek('mutable')?.boolValue ?? true;
-    final bool enableToString = annotation.peek('toString')?.boolValue ?? true;
-    final bool enableEquals = annotation.peek('equals')?.boolValue ?? true;
-    final bool enableHashCode = annotation.peek('hashCode')?.boolValue ?? true;
+    final bool enableToString = annotation.peek('enableToString')?.boolValue ?? true;
+    final bool enableEquals = annotation.peek('enableEquals')?.boolValue ?? true;
+    final bool enableHashCode = annotation.peek('enableHashCode')?.boolValue ?? true;
     final bool useDeepEquality = annotation.peek('useDeepEquality')?.boolValue ?? true;
-    final bool enableCopyWith = annotation.peek('copyWith')?.boolValue ?? true;
+    final bool enableCopyWith = annotation.peek('enableCopyWith')?.boolValue ?? true;
     final bool useDeepCopy = annotation.peek('useDeepCopy')?.boolValue ?? false;
     const String importSerializer = '\'package:crystallis/runtime/serializer.dart\'';
-    final bool enableDeserialize = annotation.peek('deserialize')?.boolValue ?? true;
+    final bool enableDeserialize = annotation.peek('enableDeserialize')?.boolValue ?? true;
 
     final fields = element.fields.where((f) => !f.isStatic).where((f) => f.getter != null).toList();
 

--- a/packages/crystallis_generator/lib/crystallis_generator.dart
+++ b/packages/crystallis_generator/lib/crystallis_generator.dart
@@ -9,6 +9,8 @@ import 'package:crystallis/runtime/serializer.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:source_gen/source_gen.dart';
 
+const String importFlag = '// crystallis_generator(add_import):';
+
 Builder crystallisBuilder(BuilderOptions options) {
   return LibraryBuilder(
     CrystallisGenerator(),
@@ -36,6 +38,30 @@ Builder crystallisBuilder(BuilderOptions options) {
           '${isTest ? testDartFormatWidth : defaultDartFormatWidth}\n'
           '${isTest || isExample ? '' : disableAnalyzer}\n'
           '${code.startsWith('$defaultFileHeader\n') ? code.substring(defaultFileHeader.length) : code}';
+
+      // add imports after crystalllis import
+      final Set<String> imports = code
+          .split('\n')
+          .where((line) => line.trim().startsWith(importFlag))
+          .map((line) => 'import ${line.substring(importFlag.length + line.indexOf(importFlag)).trim()};')
+          .toSet();
+
+      // clean code of import flags
+      code = code
+          .split('\n') //
+          .where((line) => !line.trim().startsWith(importFlag))
+          .join('\n');
+
+      final lines = code.split('\n');
+      final int crystallisImportIndex = lines.indexWhere(
+        (line) => line.startsWith("import 'package:crystallis/crystallis.dart';"),
+      );
+
+      if (crystallisImportIndex != -1) {
+        final before = lines.sublist(0, crystallisImportIndex + 1);
+        final after = lines.sublist(crystallisImportIndex + 1);
+        code = [...before, ...imports, ...after].join('\n');
+      }
 
       return DartFormatter(languageVersion: langVersion).format(code);
     },
@@ -85,6 +111,7 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
     final bool useDeepEquality = annotation.peek('useDeepEquality')?.boolValue ?? true;
     final bool enableCopyWith = annotation.peek('copyWith')?.boolValue ?? true;
     final bool useDeepCopy = annotation.peek('useDeepCopy')?.boolValue ?? false;
+    const String importSerializer = '\'package:crystallis/runtime/serializer.dart\'';
     final bool enableDeserialize = annotation.peek('deserialize')?.boolValue ?? true;
 
     final fields = element.fields.where((f) => !f.isStatic).where((f) => f.getter != null).toList();
@@ -130,7 +157,6 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
     if (!_librariesWithImports.contains(buildStep.inputId.uri)) {
       _librariesWithImports.add(buildStep.inputId.uri);
       buffer.writeln("import 'package:crystallis/crystallis.dart';");
-      buffer.writeln("import 'package:crystallis/runtime/serializer.dart';");
       buffer.writeln("import '${buildStep.inputId.uri.asPackageOrBaseName}';");
       buffer.writeln();
     }
@@ -194,6 +220,8 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
 
     // deserializer constructor
     if (enableDeserialize) {
+      buffer.writeln('  $importFlag $importSerializer');
+
       buffer.writeln('  factory $publicName.deserialize(Map<String, dynamic> data) =>');
       buffer.writeln('      $publicName(');
       for (final f in fields) {
@@ -244,6 +272,8 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
       );
 
       if (serializers.isNotEmpty) {
+        buffer.writeln('  $importFlag $importSerializer');
+
         /*
          *  Custom serializer handling
          */
@@ -265,6 +295,7 @@ class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
          *  Default serializer handling
          */
         if (f.type.isDartCoreMap) {
+          buffer.writeln('  $importFlag $importSerializer');
           buffer.writeln(
             '      serializer: MapSerializer<${_typeArguments(f.type).join(', ')}>(),',
           );

--- a/packages/crystallis_generator/lib/crystallis_generator.dart
+++ b/packages/crystallis_generator/lib/crystallis_generator.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: public_member_api_docs
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -9,8 +7,10 @@ import 'package:crystallis/runtime/serializer.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:source_gen/source_gen.dart';
 
+/// Comment flag used to indicate where imports should be added in the generated code.
 const String importFlag = '// crystallis_generator(add_import):';
 
+/// Entry point for the Crystallis code generator.
 Builder crystallisBuilder(BuilderOptions options) {
   return LibraryBuilder(
     CrystallisGenerator(),
@@ -68,6 +68,7 @@ Builder crystallisBuilder(BuilderOptions options) {
   );
 }
 
+/// Code generator for classes annotated with [Crystallise].
 class CrystallisGenerator extends GeneratorForAnnotation<Crystallise> {
   static final _validatorChecker = TypeChecker.typeNamed(Validator, inPackage: 'crystallis');
 

--- a/packages/crystallis_generator/test/generated_golden_test.dart
+++ b/packages/crystallis_generator/test/generated_golden_test.dart
@@ -241,8 +241,7 @@ class Product {
   const Product({required this.name});
 }''',
   ),
-  nonLibFolder(
-    r'''
+  nonLibFolder(r'''
 library example;
 import 'package:crystallis/crystallis.dart';
 
@@ -251,8 +250,30 @@ class User {
   String name;
 
   User({required this.name});
-}''',
-  );
+}'''),
+  noSerializerImport(r'''
+library example;
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise(mutable: true, deserialize: false)
+class User {
+  String name;
+
+  User({required this.name});
+}
+'''),
+  onlyOneSerializerImport(r'''
+library example;
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise(mutable: true, deserialize: true)
+class User {
+  String name;
+  Map<String, String> preferences;
+
+  User({required this.name, required this.preferences});
+}
+''');
 
   const TestEntry(this.testFile);
 
@@ -494,10 +515,37 @@ void main() {
 
     final generated = outputs['$outputPackage|test/user.data.g.dart']!;
 
-    print(generated);
-
     expect(generated, contains("import 'package:crystallis/crystallis.dart';"));
     expect(generated, contains("import 'user.dart';"));
+  });
+
+  test("does not import serializer if not needed", () async {
+    final input = TestEntry.noSerializerImport.testFile;
+
+    final outputs = await _runBuilder(
+      inputDartPath: '$outputPackage|lib/user.dart',
+      inputDart: input,
+    );
+
+    final generated = outputs['$outputPackage|lib/user.data.g.dart']!;
+
+    expect(generated, isNot(contains("import 'package:crystallis/runtime/serializer.dart';")));
+  });
+
+  test("imports serializer if needed, only once", () async {
+    final input = TestEntry.onlyOneSerializerImport.testFile;
+
+    final outputs = await _runBuilder(
+      inputDartPath: '$outputPackage|lib/user.dart',
+      inputDart: input,
+    );
+
+    final generated = outputs['$outputPackage|lib/user.data.g.dart']!;
+
+    expect(
+      generated.split('\n').where((line) => line.contains("import 'package:crystallis/runtime/serializer.dart';")),
+      hasLength(1),
+    );
   });
 }
 

--- a/packages/crystallis_generator/test/generated_golden_test.dart
+++ b/packages/crystallis_generator/test/generated_golden_test.dart
@@ -85,6 +85,17 @@ class User {
   });
 }''',
   ),
+  immutableWithoutCopy(
+    r'''
+library example;
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise(mutable: false, copyWith: false)
+class User {
+  final String name;
+  const User({required this.name});
+}''',
+  ),
   immutableWithMutableField(
     r'''
 library example;
@@ -241,6 +252,28 @@ class Product {
   const Product({required this.name});
 }''',
   ),
+  withDeserialize(
+    r'''
+library example;
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise(mutable: false, deserialize: true)
+class User {
+  final String name;
+  const User({required this.name});
+}''',
+  ),
+  withoutDeserialize(
+    r'''
+library example;
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise(mutable: false, deserialize: false)
+class User {
+  final String name;
+  const User({required this.name});
+}''',
+  ),
   nonLibFolder(r'''
 library example;
 import 'package:crystallis/crystallis.dart';
@@ -272,6 +305,14 @@ class User {
   Map<String, String> preferences;
 
   User({required this.name, required this.preferences});
+}
+
+@Crystallise(mutable: true, deserialize: true)
+class Menu {
+  String title;
+  Map<String, String> entries;
+
+  Menu({required this.title, required this.entries});
 }
 ''');
 
@@ -400,6 +441,7 @@ void main() {
     final generated = outputs['$outputPackage|lib/dot.data.g.dart']!;
     expect(generated, contains('if (other is! DotData) return false;'));
     expect(generated, contains('other.position == position'));
+    expect(generated, isNot(contains('DeepCollectionEquality().equals(other.position, position)')));
   });
 
   test("generates a valid (deep) equals method", () async {
@@ -426,6 +468,7 @@ void main() {
     final generated = outputs['$outputPackage|lib/dot.data.g.dart']!;
     expect(generated, contains('int get hashCode {'));
     expect(generated, contains('Object.hashAll([color, position]);'));
+    expect(generated, isNot(contains('DeepCollectionEquality().equals(other.position, position)')));
   });
 
   test("generates a valid (deep) hashCode method", () async {
@@ -477,6 +520,19 @@ void main() {
     expect(generated, contains('[...friends as List<String>]'));
   });
 
+  test('doesn\'t generate copy methods when copyWith is false', () async {
+    final input = TestEntry.immutableWithoutCopy.testFile;
+
+    final outputs = await _runBuilder(
+      inputDartPath: '$outputPackage|lib/user.dart',
+      inputDart: input,
+    );
+
+    final generated = outputs['$outputPackage|lib/user.data.g.dart']!;
+    expect(generated, isNot(contains('}) get copyWith =>')));
+    expect(generated, isNot(contains('copyFrom(CrystallisData other) =>')));
+  });
+
   test("generates a deserialize constructor", () async {
     final input = TestEntry.immutable.testFile;
 
@@ -517,6 +573,30 @@ void main() {
 
     expect(generated, contains("import 'package:crystallis/crystallis.dart';"));
     expect(generated, contains("import 'user.dart';"));
+  });
+
+  test('generates a deserialize factory when deserialize is true', () async {
+    final input = TestEntry.withDeserialize.testFile;
+
+    final outputs = await _runBuilder(
+      inputDartPath: '$outputPackage|lib/user.dart',
+      inputDart: input,
+    );
+
+    final generated = outputs['$outputPackage|lib/user.data.g.dart']!;
+    expect(generated, contains('factory UserData.deserialize('));
+  });
+
+  test('doesn\'t generate a deserialize factory when deserialize is false', () async {
+    final input = TestEntry.withoutDeserialize.testFile;
+
+    final outputs = await _runBuilder(
+      inputDartPath: '$outputPackage|lib/user.dart',
+      inputDart: input,
+    );
+
+    final generated = outputs['$outputPackage|lib/user.data.g.dart']!;
+    expect(generated, isNot(contains('factory UserData.deserialize(')));
   });
 
   test("does not import serializer if not needed", () async {


### PR DESCRIPTION
Mechanism:
- looks for any occurrence of something that will require a serializer import
- leaves a generator-only comment flag saying "hey this needs this import"
- import flags are gather, deduplicated
- imports added after crystallis import
- import flag comments are removed from output

This way we can add more imports in the future if needed (although likely not, see #8 )

ALSO fixed some `@Crystallise()` flags being ignored