### PR TITLE
Creates a warning for equals `true`

### DIFF
--- a/packages/crystallis_plugin/lib/src/plugin_integration.dart
+++ b/packages/crystallis_plugin/lib/src/plugin_integration.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/analysis_rule/analysis_rule.dart';
 import 'package:crystallis_plugin/src/rules/crystallis_rule.dart';
+import 'package:crystallis_plugin/src/rules/equals.dart';
 import 'package:crystallis_plugin/src/rules/mutability.dart';
 
 /// A mixin to handle the integration of the declared rules into the plugin.
@@ -9,6 +10,7 @@ mixin RulesMixin {
     for (var ruleFlag in CrystallisRuleFlag.values)
       switch (ruleFlag) {
         .mutability => MutabilityRule(),
+        .equals => EqualsRule(),
       },
   ];
 

--- a/packages/crystallis_plugin/lib/src/rules/crystallis_code.dart
+++ b/packages/crystallis_plugin/lib/src/rules/crystallis_code.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:analyzer/error/error.dart';
+import 'package:crystallis_generator/src/crystallis_rule_message.dart'; // ignore: implementation_imports owned package
 import 'package:crystallis_plugin/src/rules/crystallis_rule.dart';
 
 /// An enumeration of all the specfic codes that the crystallis_plugin can report on rules. This is a wrapper on
@@ -63,12 +64,11 @@ enum CrystallisCode {
   /// Checks whether a class annotated with @Crystallise(equals: true) already defines a == operator,
   /// which would prevent the generator from generating one.
   equalsDefined(
-    CrystallisLintCode(
+    CrystallisLintCode.generatorMessages(
       ruleFlag: .equals,
       severity: .WARNING,
       uniqueName: 'crystallis_equals_defined',
-      problemMessage:
-          'The == operator is already defined. The generator will not generate an == operator for this class.',
+      problemMessage: .equalAlreadyDefined,
       correctionMessage: "Consider removing the == operator or setting 'equals: false' in the @Crystallise annotation.",
     ),
   );
@@ -90,7 +90,7 @@ class CrystallisLintCode implements LintCode {
   /// {@macro crystallis_code}
   const CrystallisLintCode({
     required this.ruleFlag,
-    required this.problemMessage,
+    required String problemMessage,
     this.correctionMessage,
     this.severity = .INFO,
     this.type = .LINT,
@@ -99,6 +99,24 @@ class CrystallisLintCode implements LintCode {
        isUnresolvedIdentifier = false,
        hasPublishedDocs = false,
        isIgnorable = true,
+       _problemMessage = problemMessage, // TODO(FMorschel): Make use of private named parameters when possible.
+       _problemMessageEnum = null,
+       uniqueName = uniqueName ?? 'CrystallisLintCode.$ruleFlag';
+
+  /// {@macro crystallis_code}
+  const CrystallisLintCode.generatorMessages({
+    required this.ruleFlag,
+    required CrystallisRuleMessage problemMessage,
+    this.correctionMessage,
+    this.severity = .INFO,
+    this.type = .LINT,
+    String? uniqueName,
+  }) : url = null,
+       isUnresolvedIdentifier = false,
+       hasPublishedDocs = false,
+       isIgnorable = true,
+       _problemMessage = null,
+       _problemMessageEnum = problemMessage,
        uniqueName = uniqueName ?? 'CrystallisLintCode.$ruleFlag';
 
   /// The rule type this code is associated with.
@@ -145,7 +163,10 @@ class CrystallisLintCode implements LintCode {
   }
 
   @override
-  final String problemMessage;
+  String get problemMessage => _problemMessage ?? _problemMessageEnum!.message;
+
+  final String? _problemMessage;
+  final CrystallisRuleMessage? _problemMessageEnum;
 
   @override
   final DiagnosticSeverity severity;

--- a/packages/crystallis_plugin/lib/src/rules/crystallis_code.dart
+++ b/packages/crystallis_plugin/lib/src/rules/crystallis_code.dart
@@ -58,6 +58,19 @@ enum CrystallisCode {
       correctionMessage:
           "Consider making the constructor 'const' or changing the value for 'mutable' in @Crystallise annotation.",
     ),
+  ),
+
+  /// Checks whether a class annotated with @Crystallise(equals: true) already defines a == operator,
+  /// which would prevent the generator from generating one.
+  equalsDefined(
+    CrystallisLintCode(
+      ruleFlag: .equals,
+      severity: .WARNING,
+      uniqueName: 'crystallis_equals_defined',
+      problemMessage:
+          'The == operator is already defined. The generator will not generate an == operator for this class.',
+      correctionMessage: "Consider removing the == operator or setting 'equals: false' in the @Crystallise annotation.",
+    ),
   );
 
   const CrystallisCode(this.code);

--- a/packages/crystallis_plugin/lib/src/rules/crystallis_rule.dart
+++ b/packages/crystallis_plugin/lib/src/rules/crystallis_rule.dart
@@ -14,6 +14,15 @@ enum CrystallisRuleFlag {
         'This rule checks for mutable fields in classes annotated with @Crystallise to make sure they align with '
         "whatever 'mutable' value they were defined.",
     lint: false,
+  ),
+
+  /// {@macro equals_rule}
+  equals(
+    name: 'equals',
+    description:
+        'This rule checks for == operators manually defined in classes annotated with @Crystallise '
+        'when equals generation is enabled, as the generator will skip generation in that case.',
+    lint: false,
   );
 
   const CrystallisRuleFlag({required this.name, required this.description, this.lint = true});

--- a/packages/crystallis_plugin/lib/src/rules/equals.dart
+++ b/packages/crystallis_plugin/lib/src/rules/equals.dart
@@ -1,0 +1,54 @@
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:collection/collection.dart';
+import 'package:crystallis_plugin/src/rules/crystallis_rule.dart';
+import 'package:crystallis_plugin/src/utils/annotation.dart';
+
+/// {@template equals_rule}
+/// This rule warns when a class annotated with @Crystallise(equals: true) already defines a == operator,
+/// which causes the generator to skip generating one.
+/// {@endtemplate}
+class EqualsRule extends CrystallisRule {
+  /// {@macro equals_rule}
+  EqualsRule() : super(.equalsDefined);
+
+  @override
+  void registerNodeProcessors(RuleVisitorRegistry registry, RuleContext context) {
+    var visitor = _EqualsVisitor(this, context);
+    registry.addAnnotation(this, visitor);
+  }
+}
+
+class _EqualsVisitor extends SimpleAstVisitor<void> {
+  _EqualsVisitor(this.rule, this.context);
+  final EqualsRule rule;
+  final RuleContext context;
+
+  @override
+  void visitAnnotation(Annotation node) {
+    var enclosing = node.element?.enclosingElement;
+    if (enclosing is! ClassElement) return;
+    var parent = node.parent;
+    if (parent is! ClassDeclaration) return;
+
+    var object = node.elementAnnotation?.computeConstantValue();
+    if (object == null) return;
+    if (!Crystallise.isCrystalliseAnnotation(object)) return;
+
+    var crystallise = Crystallise.parser(object);
+    if (!crystallise.enableEquals) return;
+
+    var equalsOperator = switch (parent.body) {
+      EmptyClassBody() => null,
+      BlockClassBody(:final members) => members.whereType<MethodDeclaration>().firstWhereOrNull(
+        (m) => !m.isStatic && m.isOperator && m.name.lexeme == '==',
+      ),
+    };
+    if (equalsOperator == null) return;
+
+    rule.reportAtToken(equalsOperator.name);
+  }
+}

--- a/packages/crystallis_plugin/lib/src/rules/equals.dart
+++ b/packages/crystallis_plugin/lib/src/rules/equals.dart
@@ -49,6 +49,6 @@ class _EqualsVisitor extends SimpleAstVisitor<void> {
     };
     if (equalsOperator == null) return;
 
-    rule.reportAtToken(equalsOperator.name);
+    rule.reportAtToken(equalsOperator.name, arguments: [parent.namePart.typeName.lexeme]);
   }
 }

--- a/packages/crystallis_plugin/pubspec.yaml
+++ b/packages/crystallis_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   analyzer: ^12.0.0
   analyzer_plugin: ^0.14.7
   collection: ^1.19.1
-  crystallis_generator: #TODO(FMorschel): Change the version to a published one once it is available on pub.dev
+  crystallis_generator: ^0.0.5-dev
   meta: ^1.18.1
   path: ^1.9.0
 

--- a/packages/crystallis_plugin/pubspec.yaml
+++ b/packages/crystallis_plugin/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   analyzer: ^12.0.0
   analyzer_plugin: ^0.14.7
   collection: ^1.19.1
+  crystallis_generator: #TODO(FMorschel): Change the version to a published one once it is available on pub.dev
   meta: ^1.18.1
   path: ^1.9.0
 

--- a/packages/crystallis_plugin/test/rules/equals_test.dart
+++ b/packages/crystallis_plugin/test/rules/equals_test.dart
@@ -22,6 +22,8 @@ class EqualsTest extends AnalysisRuleTest with CrystallisDependency {
     super.setUp();
   }
 
+  /// Reports when a class annotated with @Crystallise() defines a == operator, which causes the generator to skip
+  /// generating one.
   Future<void> test_defined() async {
     await assertDiagnostics(
       '''
@@ -40,6 +42,8 @@ class MyClass {
     );
   }
 
+  /// Does not report when a class annotated with @Crystallise(equals: false) defines a == operator, as the generator
+  /// will not attempt to generate one in that case.
   Future<void> test_defined_disabled() async {
     await assertNoDiagnostics('''
 import 'package:crystallis/crystallis.dart';
@@ -55,6 +59,8 @@ class MyClass {
 ''');
   }
 
+  /// Reports when a class annotated with @Crystallise(equals: true) defines a == operator, which causes the generator
+  /// to skip generating one.
   Future<void> test_defined_explicit() async {
     await assertDiagnostics(
       '''
@@ -73,6 +79,7 @@ class MyClass {
     );
   }
 
+  /// Does not report if a class is not annotated with @Crystallise(), as the generator will not work with it.
   Future<void> test_notAnnotated() async {
     await assertNoDiagnostics('''
 class MyClass {
@@ -85,6 +92,8 @@ class MyClass {
 ''');
   }
 
+  /// Does not report if a class annotated with @Crystallise() does not define a == operator, as the generator will
+  /// generate one for it.
   Future<void> test_undefined() async {
     await assertNoDiagnostics('''
 import 'package:crystallis/crystallis.dart';

--- a/packages/crystallis_plugin/test/rules/equals_test.dart
+++ b/packages/crystallis_plugin/test/rules/equals_test.dart
@@ -1,0 +1,99 @@
+import 'package:analyzer_testing/analysis_rule/analysis_rule.dart';
+import 'package:crystallis_plugin/src/rules/crystallis_code.dart';
+import 'package:crystallis_plugin/src/rules/equals.dart';
+import 'package:essential_lints_annotations/essential_lints_annotations.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../src/crystallis_dependency.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(EqualsTest);
+  });
+}
+
+@reflectiveTest
+@SortingMembers({.method(#setUp), .methods}, alphabetizeSortedMembers: true, linesAroundSortedMembers: 1)
+class EqualsTest extends AnalysisRuleTest with CrystallisDependency {
+  @override
+  Future<void> setUp() async {
+    rule = EqualsRule();
+    await addCrystallisDependency();
+    super.setUp();
+  }
+
+  Future<void> test_defined() async {
+    await assertDiagnostics(
+      '''
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise()
+class MyClass {
+  const MyClass();
+  final int field = 0;
+
+  @override
+  bool operator ==(Object other) => other is MyClass && other.field == field;
+}
+''',
+      [error(CrystallisCode.equalsDefined.code, 148, 2)],
+    );
+  }
+
+  Future<void> test_defined_disabled() async {
+    await assertNoDiagnostics('''
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise(equals: false)
+class MyClass {
+  const MyClass();
+  final int field = 0;
+
+  @override
+  bool operator ==(Object other) => other is MyClass && other.field == field;
+}
+''');
+  }
+
+  Future<void> test_defined_explicit() async {
+    await assertDiagnostics(
+      '''
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise(equals: true)
+class MyClass {
+  const MyClass();
+  final int field = 0;
+
+  @override
+  bool operator ==(Object other) => other is MyClass && other.field == field;
+}
+''',
+      [error(CrystallisCode.equalsDefined.code, 160, 2)],
+    );
+  }
+
+  Future<void> test_notAnnotated() async {
+    await assertNoDiagnostics('''
+class MyClass {
+  const MyClass();
+  final int field = 0;
+
+  @override
+  bool operator ==(Object other) => other is MyClass && other.field == field;
+}
+''');
+  }
+
+  Future<void> test_undefined() async {
+    await assertNoDiagnostics('''
+import 'package:crystallis/crystallis.dart';
+
+@Crystallise()
+class MyClass {
+  const MyClass();
+  final int field = 0;
+}
+''');
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/kerberjg/crystallis.dart/issues/43